### PR TITLE
Update timeline list to change Timeglider to Preceden

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ More about Data-driven journalism [Wikipedia: Data-driven journalsim](https://en
  * [Venngage](https://venngage.com/)
   
 ## Visualization Tools (Timelines)
- * [Time Glider](http://timeglider.com/)  
+ * [Preceden](https://www.preceden.com/)  
  * [Tiki-Toki](http://www.tiki-toki.com/)
  * [Hstry](https://www.hstry.co/)
  * [Dipity](http://www.dipity.com/)


### PR DESCRIPTION
Howdy - I acquired Timeglider in 2019 and later shut it down. The timeglider.com domain redirects to my timeline maker, preceden.com, so figured it would be good to update the link in this list as well. Kudos for putting together this great resource.