### PR TITLE
Add Epstein Exposed — DOJ case file database

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ More about Data-driven journalism [Wikipedia: Data-driven journalsim](https://en
  * [World Bank data portal](http://data.worldbank.org)
  * [US Government open data portal](http://data.gov)
  * [UK Government open data portal](http://data.gov.uk)
+ * [Epstein Exposed](https://epsteinexposed.com) - Searchable database of 2M+ Jeffrey Epstein DOJ case files with full-text search, network graph visualization, and public REST API.
   
 ## Web scraping
 * [Scraping for Journalism: A Guide for Collecting Data](https://www.propublica.org/nerds/item/doc-dollars-guides-collecting-the-data)


### PR DESCRIPTION
Adds [Epstein Exposed](https://epsteinexposed.com), a comprehensive searchable database of 2M+ DOJ documents released under the Epstein Files Transparency Act (H.R.4405).

Features full-text + semantic search, network graph visualization, document integrity verification, and a public REST API with 27 endpoints. Used by journalists, researchers, and the public.

Added to the **Data Sets** section.