### PR TITLE
Add Albis coverage-gap news feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The practice rests on **three interconnected pillars**:
 * [Duke Reporters' Lab — Fact-checking database](https://reporterslab.org/fact-checking/)
 * [Bellingcat Toolkit](https://www.bellingcat.com/category/resources/) — Open-source investigation techniques
 * [Check (Meedan)](https://meedan.com/check) — Collaborative verification, claim documentation
+* [Albis](https://www.albis.news/?utm_source=github&utm_medium=catalog&utm_campaign=awesome_datajournalism_infoculture) — Public news feed for spotting coverage gaps and comparing which global stories your usual feed may miss
 
 ### Data integrity and provenance
 


### PR DESCRIPTION
Adds Albis as a public news feed that helps readers spot coverage gaps and compare which global stories their usual feed may miss.

I placed it under claim/source verification because the useful workflow is not “trust Albis as an authority,” but use it as a prompt to compare coverage across sources and then verify original reporting.

Link includes UTM parameters so we can measure whether this catalog route sends any useful traffic.

No endorsement implied.